### PR TITLE
null check to prevent exception

### DIFF
--- a/source/Global.js
+++ b/source/Global.js
@@ -5,7 +5,7 @@ import {WorkerManager} from "./utils/WorkerManager.js";
 
 function getBasePath()
 {
-	if(document.currentScript.src)
+	if(document.currentScript && document.currentScript.src)
 	{
 		var scriptPath = new URL(document.currentScript.src + "/..").href;
 


### PR DESCRIPTION
Throws exceptions in an Angular project using @cognite/reveal  in chrome.
![potree-error](https://user-images.githubusercontent.com/1345693/77415905-25f76800-6de9-11ea-8656-bd84140d8701.png)

This fix is available in tentone/potree-core project. Please check if this is ok.